### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@came.plus/test",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "https://came.plus/test: Simple CAME+ testing framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request updates the version number of the `@came.plus/test` package in the `package.json` file. The version has been incremented from `0.0.1` to `0.1.0`, indicating a minor update with backward-compatible changes.