### PR TITLE
Update npm workflow and bump version to 0.1.1

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -9,23 +9,28 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        # Checks out the repository code to the runner
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '20' # Node.js 20 LTS
           registry-url: 'https://registry.npmjs.org' # Default registry for npm
+        # Sets up Node.js environment for the workflow
 
       - name: Install dependencies
         run: npm ci
+        # Installs dependencies using npm ci for a clean install
 
       - name: Build project
         run: npm run build
+        # Builds the project using the build script defined in package.json
 
       - name: Publish to npm
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # Authentication for npm
+        # Publishes the package to npm using the token stored in GitHub secrets
 
       - name: Extract version from package.json
         run: |
@@ -40,13 +45,17 @@ jobs:
           git push origin :refs/tags/${{ env.VERSION }} || true
         # Deletes the tag locally and remotely, ignores errors if not present
 
-      - name: Create GitHub Release and Upload Asset
-        uses: softprops/action-gh-release@v1
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.VERSION }} # e.g., 0.0.11
-          name: ${{ env.VERSION }} # e.g., 0.0.11
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
           draft: false
           prerelease: false
+        # Creates a new release on GitHub with the version from package.json
 
       - name: npm pack
         run: npm pack # Creates a .tgz file from the package.json
@@ -61,8 +70,10 @@ jobs:
           asset_path: ./came.plus-test-${{ env.VERSION }}.tgz # Path to the .tgz file
           asset_name: came.plus-test-${{ env.VERSION }}.tgz # Name of the asset in the release
           asset_content_type: application/gzip # Content type for .tgz files
+        # Uploads the .tgz file created by npm pack to the GitHub release
 
       - name: List all files
         run: |
           echo "Listing all files in the current directory: $(pwd)"
           ls -R
+        # Lists all files in the current directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@came.plus/test",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "https://came.plus/test: Simple CAME+ testing framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/publish-npm.yaml` file to improve the GitHub Actions workflow for publishing to npm and creating releases, as well as a version bump in `package.json`.

### Workflow improvements:
* Added comments throughout the workflow steps in `.github/workflows/publish-npm.yaml` to improve clarity and explain the purpose of each step. [[1]](diffhunk://#diff-c65a76fdf1b536e4b9454d397b8d2d90128798f2562bcf34ef5473d38fa89accR12-R33) [[2]](diffhunk://#diff-c65a76fdf1b536e4b9454d397b8d2d90128798f2562bcf34ef5473d38fa89accR73-R79)
* Replaced the `softprops/action-gh-release` action with `actions/create-release` for creating GitHub releases, including adding an `id` for the step and updating the environment variable and input parameters.

### Version update:
* Updated the version in `package.json` from `0.1.0` to `0.1.1` to reflect a new release.