### PR TITLE
Update GitHub Actions workflow to create a release and upload asset, bump version to 0.1.2

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -45,32 +45,21 @@ jobs:
           git push origin :refs/tags/${{ env.VERSION }} || true
         # Deletes the tag locally and remotely, ignores errors if not present
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.VERSION }}
-          release_name: ${{ env.VERSION }}
-          draft: false
-          prerelease: false
-        # Creates a new release on GitHub with the version from package.json
-
       - name: npm pack
         run: npm pack # Creates a .tgz file from the package.json
-        # This will create a file named came.plus-test-<version>.tgz in the current directory 
+        # Creates a file named came.plus-test-<version>.tgz in the current directory 
 
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+      - name: Create GitHub Release and Upload Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.VERSION }}
+          name: ${{ env.VERSION }}
+          draft: false
+          prerelease: false
+          files: ./came.plus-test-${{ env.VERSION }}.tgz # Path to the renamed .tgz file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Use default GITHUB_TOKEN with updated permissions
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # URL from create-release step
-          asset_path: ./came.plus-test-${{ env.VERSION }}.tgz # Path to the .tgz file
-          asset_name: came.plus-test-${{ env.VERSION }}.tgz # Name of the asset in the release
-          asset_content_type: application/gzip # Content type for .tgz files
-        # Uploads the .tgz file created by npm pack to the GitHub release
+        # Creates a GitHub release with the specified tag and uploads the packed .tgz file as an additional asset
 
       - name: List all files
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@came.plus/test",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "https://came.plus/test: Simple CAME+ testing framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing to npm and increments the package version in `package.json`. The most significant changes involve consolidating steps in the workflow to streamline the release process and updating the package version to reflect a new release.

### Workflow improvements:

* [`.github/workflows/publish-npm.yaml`](diffhunk://#diff-c65a76fdf1b536e4b9454d397b8d2d90128798f2562bcf34ef5473d38fa89accL48-R62): Replaced the `actions/create-release` and `actions/upload-release-asset` steps with a single `softprops/action-gh-release` step. This change simplifies the release process by combining the creation of a GitHub release and the upload of the `.tgz` file into one step.

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.1.1` to `0.1.2` to reflect the new release.